### PR TITLE
Error Handling Simplification & Bug Fixes & Enhancement

### DIFF
--- a/src/components/atoms/Notice/index.js
+++ b/src/components/atoms/Notice/index.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Header, Message, Transition } from 'semantic-ui-react'
+
+const Notice = ({ openSuccess, openError, textSuccess, textError }) => {
+  return (
+    <div>
+      <Transition visible={openSuccess}>
+        <Message
+          style={{ left: '50%', transform: 'translateX(-51%)', top: '10%', position: 'fixed', zIndex: 1000 }}
+          success
+        >
+          <Header textAlign="center" content={textSuccess} />
+        </Message>
+      </Transition>
+      <Transition visible={openError}>
+        <Message
+          style={{ left: '50%', transform: 'translateX(-51%)', top: '10%', position: 'fixed', zIndex: 1000 }}
+          negative
+        >
+          <Header textAlign="center" content={textError} />
+        </Message>
+      </Transition>
+    </div>
+  )
+}
+
+Notice.propTypes = {
+  openSuccess: PropTypes.bool,
+  openError: PropTypes.bool,
+  textSuccess: PropTypes.string,
+  textError: PropTypes.string,
+}
+
+Notice.defaultProps = {
+  textSuccess: 'Updated Successfully.',
+  textError: 'Some Errors Occurred.',
+}
+
+export default Notice

--- a/src/components/atoms/Notice/index.stories.js
+++ b/src/components/atoms/Notice/index.stories.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { storiesOf } from '@kadira/storybook'
+import Notice from '.'
+
+storiesOf('Notice', module)
+  .add('default', () => (
+    <Notice>Hello</Notice>
+  ))
+  .add('reverse', () => (
+    <Notice reverse>Hello</Notice>
+  ))

--- a/src/components/atoms/Notice/index.test.js
+++ b/src/components/atoms/Notice/index.test.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Notice from '.'
+
+const wrap = (props = {}) => shallow(<Notice {...props} />)
+
+it('renders children when passed in', () => {
+  const wrapper = wrap({ children: 'test' })
+  expect(wrapper.contains('test')).toBe(true)
+})
+
+it('renders props when passed in', () => {
+  const wrapper = wrap({ id: 'foo' })
+  expect(wrapper.find({ id: 'foo' })).toHaveLength(1)
+})

--- a/src/components/molecules/SearchLecture/index.js
+++ b/src/components/molecules/SearchLecture/index.js
@@ -48,7 +48,12 @@ class SearchLecture extends React.Component {
             Search Lecture
           </Modal.Header>
           <Modal.Content>
-            <Form onSubmit={this.handleSearchLecture}>
+            <Form
+              onSubmit={() => {
+                this.setState({ page: 1 })
+                this.handleSearchLecture()
+              }}
+            >
               <Form.Input
                 label="Course Name"
                 name="course.name.abbrev"
@@ -82,7 +87,7 @@ class SearchLecture extends React.Component {
                 lastItem={{ content: <Icon name="angle double right" />, icon: true }}
                 prevItem={{ content: <Icon name="angle left" />, icon: true }}
                 nextItem={{ content: <Icon name="angle right" />, icon: true }}
-                totalPages={parseInt((this.props.count - 1) / limit) + 1}
+                totalPages={Math.floor((this.props.count - 1) / limit) + 1}
                 activePage={this.state.page}
                 onPageChange={this.handlePageChange}
               />

--- a/src/components/molecules/TimeTable/index.js
+++ b/src/components/molecules/TimeTable/index.js
@@ -227,8 +227,8 @@ class TimeTable extends React.Component {
 
     return (
       <div>
-        {this.props.id !== null &&
         <Menu tabular attached="top">
+          {this.props.id !== null &&
           <Menu.Item active fitted>
             {!this.state.isModifyingTitle ?
               <div style={{ paddingLeft: 10, paddingRight: 10 }}>
@@ -268,9 +268,9 @@ class TimeTable extends React.Component {
                 />
               </Form>
             }
-          </Menu.Item>
+          </Menu.Item>}
           <Menu.Menu position="right">
-            {this.props.canModify &&
+            {(this.props.id !== null || (this.props.canModify && this.props.canCreate)) &&
             <Menu.Item active fitted>
               <Popup
                 trigger={<div>
@@ -291,6 +291,7 @@ class TimeTable extends React.Component {
                 inverted
               />
             </Menu.Item>}
+            {this.props.id !== null &&
             <Menu.Item active fitted>
               <div style={{ paddingLeft: 10, paddingRight: 10 }}>
                 {this.props.canCopyToMy &&
@@ -363,10 +364,9 @@ class TimeTable extends React.Component {
                   inverted={!this.state.isDeleting}
                 />}
               </div>
-            </Menu.Item>
+            </Menu.Item>}
           </Menu.Menu>
         </Menu>
-        }
         <Segment attached>
           {this.createTimeTable()}
           {this.props.id !== null &&
@@ -404,6 +404,7 @@ TimeTable.propTypes = {
   canModify: PropTypes.bool,
   canCopyToMy: PropTypes.bool,
   canDelete: PropTypes.bool,
+  canCreate: PropTypes.bool,
   onModifyContent: PropTypes.func,
   onAddLecture: PropTypes.func,
   onDeleteLecture: PropTypes.func,

--- a/src/components/organisms/BookmarkTab/index.js
+++ b/src/components/organisms/BookmarkTab/index.js
@@ -16,6 +16,7 @@ const BookmarkTab = ({ myTimeTable, bookmarkedTimeTables, bookmarkedTimeTable, o
         {...myTimeTable}
         canModify
         canDelete
+        canCreate
         canCopyToMy={false}
         onDeleteTimeTable={(timeTableId) => timeTableId !== null ? onDeleteTimeTable(timeTableId, 'my', null) : console.log('There is no timetable')}
       />

--- a/src/components/organisms/ReceiveTab/index.js
+++ b/src/components/organisms/ReceiveTab/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import TimeTable from '../../../containers/TimeTable'
-import { getLectureIdsWithout } from '../RecommendTab'
+import { getLectureIds, getLectureIdsWithout } from '../RecommendTab'
 
 const ReceiveTab = ({ myTimeTable, receivedTimeTables, receivedTimeTable, onSelectReceivedTimeTable, onUpdateMyTimeTable, onDeleteTimeTable }) => {
   let inputReceivedTimeTableIndex = { value: 0 }
@@ -10,11 +10,13 @@ const ReceiveTab = ({ myTimeTable, receivedTimeTables, receivedTimeTable, onSele
     <div>
       <h1>My TimeTable</h1>
       <TimeTable
+        onAddLecture={(newLectureId) => onUpdateMyTimeTable(myTimeTable.id, { lectures: getLectureIds(myTimeTable) }, newLectureId)}
         onModifyContent={(content) => onUpdateMyTimeTable(myTimeTable.id, content, null)}
         onDeleteLecture={(lectureId) => onUpdateMyTimeTable(myTimeTable.id, { lectures: getLectureIdsWithout(lectureId, myTimeTable) }, -lectureId)}
         {...myTimeTable}
         canModify
         canDelete
+        canCreate
         canCopyToMy={false}
         onDeleteTimeTable={(timeTableId) => timeTableId !== null ? onDeleteTimeTable(timeTableId, 'my', null) : console.log('There is no timetable')}
       />

--- a/src/components/organisms/RecommendTab/index.js
+++ b/src/components/organisms/RecommendTab/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import SearchLecture from '../../../containers/SearchLecture'
 import TimeTable from '../../../containers/TimeTable'
 
 export const getLectureIds = (timeTable) => {
@@ -34,6 +33,7 @@ const RecommendTab = ({ myTimeTable, recommendedTimeTables, recommendedTimeTable
         onModifyContent={(content) => onUpdateMyTimeTable(myTimeTable.id, content, null)}
         canModify
         canDelete
+        canCreate
         canCopyToMy={false}
         onDeleteTimeTable={(timeTableId) => timeTableId !== null ? onDeleteTimeTable(timeTableId, 'my', null) : console.log('There is no timetable')}
       />

--- a/src/components/organisms/SettingsTab/index.js
+++ b/src/components/organisms/SettingsTab/index.js
@@ -58,6 +58,10 @@ class SettingsTab extends React.Component {
     this.props.onGetNotRecommendCourses(this.props.notRecommends)
   }
 
+  componentWillUnmount() {
+    this.props.onSetError(initialErrorUnit)
+  }
+
   handleChange = (e, { name, value }) => {
     this.setState({ [name]: value })
   }
@@ -312,7 +316,6 @@ SettingsTab.propTypes = {
   onGetNotRecommendCourses: PropTypes.func,
   onDeleteFromNotRecommends: PropTypes.func,
   onSetError: PropTypes.func,
-  onExit: PropTypes.func,
 }
 
 export default SettingsTab

--- a/src/components/organisms/SettingsTab/index.js
+++ b/src/components/organisms/SettingsTab/index.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Form, Message, Button, Header, Transition, Divider, Popup, List } from 'semantic-ui-react'
-import { customErrors, initErrors, updateErrors } from '../../../services/error_utility'
+import { customErrors } from '../../../services/error_utility'
+import { initialErrorUnit } from '../../../store/ttrs/selectors'
+import Notice from '../../atoms/Notice'
 
 class SettingsTab extends React.Component {
   static getDerivedStateFromProps(props, state) {
@@ -52,7 +54,6 @@ class SettingsTab extends React.Component {
       response: props.response,
       notice: false,
     }
-    this.errors = initErrors()
 
     this.gradeOptions = [1, 2, 3, 4, 5, 6].map(grade => ({ key: grade, text: grade, value: grade }))
     this.collegeOptions = props.colleges.map((college, index) => ({ key: college.id, text: college.name, value: index }))
@@ -86,12 +87,11 @@ class SettingsTab extends React.Component {
       passwordConfirm: [this.state.password === this.state.passwordConfirm, 'Two passwords should be same.'],
     })
     if (errors !== null) {
-      this.errors = errors
-      this.props.onClearError()
-      this.forceUpdate()
+      this.props.onSetError(errors)
       return
     }
 
+    this.props.onSetError(initialErrorUnit)
     let info = {
       username: this.state.username,
       grade: this.state.grade,
@@ -119,40 +119,32 @@ class SettingsTab extends React.Component {
   }
 
   handleWithdraw = () => {
-    if (this.state.passwordWithdraw === this.props.password) {
-      this.props.onWithdraw()
+    const errors = customErrors({
+      passwordWithdraw: [this.state.passwordWithdraw === this.props.password, 'Incorrect password.'],
+    })
+    if (errors !== null) {
+      this.props.onSetError({ bools: errors.bools, texts: {} })
       return
     }
-    this.errors.bools.passwordWithdraw = true
-    this.forceUpdate()
+
+    this.props.onSetError(initialErrorUnit)
+    this.props.onWithdraw()
   }
 
   render() {
-    this.errors = updateErrors(this.errors, this.props.errors)
     if (this.state.notice) {
       setTimeout(() => {
         this.setState({ notice: false })
       }, 2000)
     }
+    const errors = this.props.errors
 
     return (
       <div>
-        <Transition visible={this.state.notice && this.state.response > 0}>
-          <Message
-            style={{ left: '50%', transform: 'translateX(-51%)', top: '10%', position: 'fixed', zIndex: 1000 }}
-            success
-          >
-            <Header textAlign="center" content="Updated Successfully." />
-          </Message>
-        </Transition>
-        <Transition visible={this.state.notice && this.state.response < 0}>
-          <Message
-            style={{ left: '50%', transform: 'translateX(-51%)', top: '10%', position: 'fixed', zIndex: 1000 }}
-            negative
-          >
-            <Header textAlign="center" content="Some Errors Occurred." />
-          </Message>
-        </Transition>
+        <Notice
+          openSuccess={this.state.notice && this.state.response > 0}
+          openError={this.state.notice && this.state.response < 0}
+        />
         <div>
           <Header as="h2" content="Update Profile" />
           <Form onSubmit={this.handleUpdateInfo}>
@@ -165,7 +157,7 @@ class SettingsTab extends React.Component {
               type="password"
               name="passwordOld"
               value={this.state.passwordOld}
-              error={this.errors.bools.passwordOld}
+              error={errors.bools.passwordOld}
               onChange={this.handleChange}
             />
             <Form.Input
@@ -176,7 +168,7 @@ class SettingsTab extends React.Component {
               type="password"
               name="password"
               value={this.state.password}
-              error={this.errors.bools.password}
+              error={errors.bools.password}
               onChange={this.handleChange}
             />
             <Form.Input
@@ -187,7 +179,7 @@ class SettingsTab extends React.Component {
               type="password"
               name="passwordConfirm"
               value={this.state.passwordConfirm}
-              error={this.errors.bools.passwordConfirm}
+              error={errors.bools.passwordConfirm}
               onChange={this.handleChange}
             />
             <Form.Select
@@ -197,7 +189,7 @@ class SettingsTab extends React.Component {
               options={this.gradeOptions}
               name="grade"
               value={this.state.grade}
-              error={this.errors.bools.grade}
+              error={errors.bools.grade}
               onChange={this.handleChange}
             />
             <Form.Select
@@ -207,7 +199,7 @@ class SettingsTab extends React.Component {
               options={this.collegeOptions}
               name="collegeIndex"
               value={this.state.collegeIndex}
-              error={this.errors.bools.college}
+              error={errors.bools.college}
               onChange={(e, { name, value }) => {
                 this.setState({ [name]: value })
                 this.setState({ departmentIndex: null })
@@ -220,7 +212,7 @@ class SettingsTab extends React.Component {
               options={this.departmentOptions}
               name="departmentIndex"
               value={this.state.departmentIndex}
-              error={this.errors.bools.department}
+              error={errors.bools.department}
               onChange={(e, { name, value }) => {
                 this.setState({ [name]: value })
                 this.setState({ majorIndex: null })
@@ -232,16 +224,16 @@ class SettingsTab extends React.Component {
               options={this.majorOptions}
               name="majorIndex"
               value={this.state.majorIndex}
-              error={this.errors.bools.major}
+              error={errors.bools.major}
               onChange={this.handleChange}
             />
             <Button type="submit" color="teal">Update</Button>
           </Form>
-          {Object.keys(this.errors.texts).length > 0 &&
+          {Object.keys(errors.texts).length > 0 &&
           <Message
             negative
             header="There are some errors with your submission"
-            list={Object.keys(this.errors.texts).map(key => this.errors.texts[key])}
+            list={Object.keys(errors.texts).map(key => errors.texts[key])}
           />}
         </div>
         <Divider />
@@ -279,7 +271,7 @@ class SettingsTab extends React.Component {
               <Form.Input
                 name="passwordWithdraw"
                 onChange={this.handleChange}
-                error={this.errors.bools.passwordWithdraw}
+                error={errors.bools.passwordWithdraw}
                 type="password"
                 placeholder="Input your password..."
                 action={<Popup
@@ -317,7 +309,7 @@ SettingsTab.propTypes = {
   onWithdraw: PropTypes.func,
   onGetNotRecommendCourses: PropTypes.func,
   onDeleteFromNotRecommends: PropTypes.func,
-  onClearError: PropTypes.func,
+  onSetError: PropTypes.func,
   onExit: PropTypes.func,
 }
 

--- a/src/components/organisms/SettingsTab/index.js
+++ b/src/components/organisms/SettingsTab/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Form, Message, Button, Header, Transition, Divider, Popup, List } from 'semantic-ui-react'
+import { Form, Message, Button, Header, Divider, Popup, List } from 'semantic-ui-react'
 import { customErrors } from '../../../services/error_utility'
 import { initialErrorUnit } from '../../../store/ttrs/selectors'
 import Notice from '../../atoms/Notice'
@@ -55,25 +55,6 @@ class SettingsTab extends React.Component {
       notice: false,
     }
 
-    this.gradeOptions = [1, 2, 3, 4, 5, 6].map(grade => ({ key: grade, text: grade, value: grade }))
-    this.collegeOptions = props.colleges.map((college, index) => ({ key: college.id, text: college.name, value: index }))
-    this.departmentOptions = [{ key: -1, text: '---', value: null }]
-    if (this.state.collegeIndex !== null) {
-      this.departmentOptions.push(...props.colleges[this.state.collegeIndex].departments.map((department, index) => ({
-        key: department.id,
-        text: department.name,
-        value: index,
-      })))
-    }
-    this.majorOptions = [{ key: -1, text: '---', value: null }]
-    if (this.state.departmentIndex !== null) {
-      this.majorOptions.push(...props.colleges[this.state.collegeIndex].departments[this.state.departmentIndex].majors.map((major, index) => ({
-        key: major.id,
-        text: major.name,
-        value: index,
-      })))
-    }
-
     this.props.onGetNotRecommendCourses(this.props.notRecommends)
   }
 
@@ -95,19 +76,21 @@ class SettingsTab extends React.Component {
     let info = {
       username: this.state.username,
       grade: this.state.grade,
-      college: this.props.colleges[this.state.collegeIndex].id,
     }
+    const college = this.props.colleges[this.state.collegeIndex].id
+    let department = null
+    let major = null
     if (this.state.departmentIndex !== null) {
-      info = {
-        ...info,
-        department: this.props.colleges[this.state.collegeIndex].departments[this.state.departmentIndex].id,
-      }
+      department = this.props.colleges[this.state.collegeIndex].departments[this.state.departmentIndex].id
       if (this.state.majorIndex !== null) {
-        info = {
-          ...info,
-          major: this.props.colleges[this.state.collegeIndex].departments[this.state.departmentIndex].majors[this.state.majorIndex].id,
-        }
+        major = this.props.colleges[this.state.collegeIndex].departments[this.state.departmentIndex].majors[this.state.majorIndex].id
       }
+    }
+    info = {
+      ...info,
+      college,
+      department,
+      major,
     }
     if (this.state.password.trim()) {
       info = {
@@ -138,6 +121,25 @@ class SettingsTab extends React.Component {
       }, 2000)
     }
     const errors = this.props.errors
+
+    const gradeOptions = [1, 2, 3, 4, 5, 6].map(grade => ({ key: grade, text: grade, value: grade }))
+    const collegeOptions = this.props.colleges.map((college, index) => ({ key: college.id, text: college.name, value: index }))
+    const departmentOptions = [{ key: -1, text: '---', value: null }]
+    if (this.state.collegeIndex !== null) {
+      departmentOptions.push(...this.props.colleges[this.state.collegeIndex].departments.map((department, index) => ({
+        key: department.id,
+        text: department.name,
+        value: index,
+      })))
+    }
+    const majorOptions = [{ key: -1, text: '---', value: null }]
+    if (this.state.departmentIndex !== null) {
+      majorOptions.push(...this.props.colleges[this.state.collegeIndex].departments[this.state.departmentIndex].majors.map((major, index) => ({
+        key: major.id,
+        text: major.name,
+        value: index,
+      })))
+    }
 
     return (
       <div>
@@ -186,7 +188,7 @@ class SettingsTab extends React.Component {
               label="Grade"
               required
               placeholder="Grade"
-              options={this.gradeOptions}
+              options={gradeOptions}
               name="grade"
               value={this.state.grade}
               error={errors.bools.grade}
@@ -196,7 +198,7 @@ class SettingsTab extends React.Component {
               label="College"
               required
               placeholder="College"
-              options={this.collegeOptions}
+              options={collegeOptions}
               name="collegeIndex"
               value={this.state.collegeIndex}
               error={errors.bools.college}
@@ -209,7 +211,7 @@ class SettingsTab extends React.Component {
             <Form.Select
               label="Department"
               placeholder="Department"
-              options={this.departmentOptions}
+              options={departmentOptions}
               name="departmentIndex"
               value={this.state.departmentIndex}
               error={errors.bools.department}
@@ -221,7 +223,7 @@ class SettingsTab extends React.Component {
             <Form.Select
               label="Major"
               placeholder="Major"
-              options={this.majorOptions}
+              options={majorOptions}
               name="majorIndex"
               value={this.state.majorIndex}
               error={errors.bools.major}

--- a/src/components/pages/SignIn/index.js
+++ b/src/components/pages/SignIn/index.js
@@ -42,7 +42,13 @@ class SignIn extends React.Component {
             <Header as="h1" color="teal" textAlign="center">
               TTRS
             </Header>
-            <Form size="large" onSubmit={this.handleSignIn}>
+            <Form
+              size="large"
+              onSubmit={() => {
+                this.props.onClearError()
+                this.handleSignIn()
+              }}
+            >
               <Segment raised>
                 <Form.Input
                   fluid
@@ -71,10 +77,10 @@ class SignIn extends React.Component {
                 </Button.Group>
               </Segment>
             </Form>
-            {Object.keys(this.props.errors).length > 0 &&
+            {this.props.errors.texts.detail &&
             <Message
               negative
-              header="Incorrect username or password."
+              header={this.props.errors.texts.detail.substring(8)}
             />}
           </Grid.Column>
         </Grid>

--- a/src/components/pages/SignUp/index.js
+++ b/src/components/pages/SignUp/index.js
@@ -1,28 +1,62 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Form, Grid, Header, Segment, Button, Message } from 'semantic-ui-react'
-import { customErrors, initErrors, updateErrors } from '../../../services/error_utility'
+import { customErrors } from '../../../services/error_utility'
+import { initialErrorUnit } from '../../../store/ttrs/selectors'
+import Notice from '../../atoms/Notice'
 
 class SignUp extends React.Component {
-  static getDerivedStateFromProps(props) {
+  static getDerivedStateFromProps(props, state) {
     if (props.toSignIn) {
-      props.onExit()
-      props.router.push('/sign-in')
+      setTimeout(() => {
+        props.onExit()
+        props.router.push('/sign-in')
+      }, 4000)
+    }
+    if (state.response !== props.response) {
+      return {
+        response: props.response,
+        notice: true,
+      }
     }
     return null
   }
 
-  state = {
-    username: '',
-    password: '',
-    passwordConfirm: '',
-    email: '',
-    grade: null,
-    collegeIndex: null,
-    departmentIndex: null,
-    majorIndex: null,
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      username: '',
+      password: '',
+      passwordConfirm: '',
+      email: '',
+      grade: null,
+      collegeIndex: null,
+      departmentIndex: null,
+      majorIndex: null,
+      response: props.response,
+      notice: false,
+    }
+
+    this.gradeOptions = [1, 2, 3, 4, 5, 6].map(grade => ({ key: grade, text: grade, value: grade }))
+    this.collegeOptions = props.colleges.map((college, index) => ({ key: college.id, text: college.name, value: index }))
+    this.departmentOptions = [{ key: -1, text: '---', value: null }]
+    if (this.state.collegeIndex !== null) {
+      this.departmentOptions.push(...props.colleges[this.state.collegeIndex].departments.map((department, index) => ({
+        key: department.id,
+        text: department.name,
+        value: index,
+      })))
+    }
+    this.majorOptions = [{ key: -1, text: '---', value: null }]
+    if (this.state.departmentIndex !== null) {
+      this.majorOptions.push(...props.colleges[this.state.collegeIndex].departments[this.state.departmentIndex].majors.map((major, index) => ({
+        key: major.id,
+        text: major.name,
+        value: index,
+      })))
+    }
   }
-  errors = initErrors()
 
   handleChange = (e, { name, value }) => {
     this.setState({ [name]: value })
@@ -35,13 +69,11 @@ class SignUp extends React.Component {
       college: [this.state.collegeIndex !== null, 'This field may not be blank.'],
     })
     if (errors !== null) {
-      this.errors = errors
-      this.props.onClearError()
-      this.forceUpdate()
+      this.props.onSetError(errors)
       return
     }
-    this.errors = initErrors()
 
+    this.props.onSetError(initialErrorUnit)
     this.props.onSignUp(
       this.state.username,
       this.state.password,
@@ -55,8 +87,12 @@ class SignUp extends React.Component {
   }
 
   render() {
-    this.errors = updateErrors(this.errors, this.props.errors)
-
+    if (this.state.notice) {
+      setTimeout(() => {
+        this.setState({ notice: false })
+      }, this.state.response > 0 ? 4000 : 2000)
+    }
+    const errors = this.props.errors
     const gradeOptions = [1, 2, 3, 4].map(grade => ({ key: grade, text: grade, value: grade }))
     const collegeOptions = this.props.colleges.map((college, index) => ({ key: college.id, text: college.name, value: index }))
     const departmentOptions = [{ key: -1, text: '---', value: null }]
@@ -85,6 +121,11 @@ class SignUp extends React.Component {
             height: 100%;
           }`}
         </style>
+        <Notice
+          openSuccess={this.state.notice && this.state.response > 0}
+          openError={this.state.notice && this.state.response < 0}
+          textSuccess={<div>You have successfully joined the membership.<br />Return to sign in page...</div>}
+        />
         <Grid
           style={{ height: '100%' }}
           verticalAlign="middle"
@@ -105,7 +146,7 @@ class SignUp extends React.Component {
                   placeholder="Username"
                   name="username"
                   value={this.state.username}
-                  error={this.errors.bools.username}
+                  error={errors.bools.username}
                   onChange={this.handleChange}
                 />
                 <Form.Group widths="equal">
@@ -119,7 +160,7 @@ class SignUp extends React.Component {
                     type="password"
                     name="password"
                     value={this.state.password}
-                    error={this.errors.bools.password}
+                    error={errors.bools.password}
                     onChange={this.handleChange}
                   />
                   <Form.Input
@@ -132,7 +173,7 @@ class SignUp extends React.Component {
                     type="password"
                     name="passwordConfirm"
                     value={this.state.passwordConfirm}
-                    error={this.errors.bools.passwordConfirm}
+                    error={errors.bools.passwordConfirm}
                     onChange={this.handleChange}
                   />
                 </Form.Group>
@@ -145,7 +186,7 @@ class SignUp extends React.Component {
                   type="email"
                   name="email"
                   value={this.state.email}
-                  error={this.errors.bools.email}
+                  error={errors.bools.email}
                   onChange={this.handleChange}
                 />
                 <Form.Select
@@ -155,7 +196,7 @@ class SignUp extends React.Component {
                   options={gradeOptions}
                   name="grade"
                   value={this.state.grade}
-                  error={this.errors.bools.grade}
+                  error={errors.bools.grade}
                   onChange={this.handleChange}
                 />
                 <Form.Select
@@ -165,7 +206,7 @@ class SignUp extends React.Component {
                   options={collegeOptions}
                   name="collegeIndex"
                   value={this.state.collegeIndex}
-                  error={this.errors.bools.college}
+                  error={errors.bools.college}
                   onChange={(e, { name, value }) => {
                     this.setState({ [name]: value })
                     this.setState({ departmentIndex: null })
@@ -178,7 +219,7 @@ class SignUp extends React.Component {
                   options={departmentOptions}
                   name="departmentIndex"
                   value={this.state.departmentIndex}
-                  error={this.errors.bools.department}
+                  error={errors.bools.department}
                   onChange={(e, { name, value }) => {
                     this.setState({ [name]: value })
                     this.setState({ majorIndex: null })
@@ -190,7 +231,7 @@ class SignUp extends React.Component {
                   options={majorOptions}
                   name="majorIndex"
                   value={this.state.majorIndex}
-                  error={this.errors.bools.major}
+                  error={errors.bools.major}
                   onChange={this.handleChange}
                 />
                 <Button.Group widths="2" >
@@ -199,11 +240,11 @@ class SignUp extends React.Component {
                 </Button.Group>
               </Segment>
             </Form>
-            {Object.keys(this.errors.bools).length > 0 &&
+            {Object.keys(errors.texts).length > 0 &&
             <Message
               negative
               header="There are some errors with your submission"
-              list={Object.keys(this.errors.texts).map(key => this.errors.texts[key])}
+              list={Object.keys(errors.texts).map(key => errors.texts[key])}
             />}
           </Grid.Column>
         </Grid>
@@ -214,10 +255,11 @@ class SignUp extends React.Component {
 
 SignUp.propTypes = {
   onSignUp: PropTypes.func,
-  onClearError: PropTypes.func,
+  onSetError: PropTypes.func,
   toSignIn: PropTypes.bool,
   colleges: PropTypes.array,
   errors: PropTypes.object,
+  response: PropTypes.number,
   router: PropTypes.object,
   onExit: PropTypes.func,
 }

--- a/src/components/pages/SignUp/index.js
+++ b/src/components/pages/SignUp/index.js
@@ -9,7 +9,6 @@ class SignUp extends React.Component {
   static getDerivedStateFromProps(props, state) {
     if (props.toSignIn) {
       setTimeout(() => {
-        props.onExit()
         props.router.push('/sign-in')
       }, 4000)
     }

--- a/src/components/pages/SignUp/index.js
+++ b/src/components/pages/SignUp/index.js
@@ -39,6 +39,10 @@ class SignUp extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    this.props.onSetError(initialErrorUnit)
+  }
+
   handleChange = (e, { name, value }) => {
     this.setState({ [name]: value })
   }
@@ -243,7 +247,6 @@ SignUp.propTypes = {
   errors: PropTypes.object,
   response: PropTypes.number,
   router: PropTypes.object,
-  onExit: PropTypes.func,
 }
 
 export default SignUp

--- a/src/components/pages/SignUp/index.js
+++ b/src/components/pages/SignUp/index.js
@@ -37,25 +37,6 @@ class SignUp extends React.Component {
       response: props.response,
       notice: false,
     }
-
-    this.gradeOptions = [1, 2, 3, 4, 5, 6].map(grade => ({ key: grade, text: grade, value: grade }))
-    this.collegeOptions = props.colleges.map((college, index) => ({ key: college.id, text: college.name, value: index }))
-    this.departmentOptions = [{ key: -1, text: '---', value: null }]
-    if (this.state.collegeIndex !== null) {
-      this.departmentOptions.push(...props.colleges[this.state.collegeIndex].departments.map((department, index) => ({
-        key: department.id,
-        text: department.name,
-        value: index,
-      })))
-    }
-    this.majorOptions = [{ key: -1, text: '---', value: null }]
-    if (this.state.departmentIndex !== null) {
-      this.majorOptions.push(...props.colleges[this.state.collegeIndex].departments[this.state.departmentIndex].majors.map((major, index) => ({
-        key: major.id,
-        text: major.name,
-        value: index,
-      })))
-    }
   }
 
   handleChange = (e, { name, value }) => {
@@ -93,7 +74,8 @@ class SignUp extends React.Component {
       }, this.state.response > 0 ? 4000 : 2000)
     }
     const errors = this.props.errors
-    const gradeOptions = [1, 2, 3, 4].map(grade => ({ key: grade, text: grade, value: grade }))
+
+    const gradeOptions = [1, 2, 3, 4, 5, 6].map(grade => ({ key: grade, text: grade, value: grade }))
     const collegeOptions = this.props.colleges.map((college, index) => ({ key: college.id, text: college.name, value: index }))
     const departmentOptions = [{ key: -1, text: '---', value: null }]
     if (this.state.collegeIndex !== null) {

--- a/src/containers/LecturePopup.js
+++ b/src/containers/LecturePopup.js
@@ -35,7 +35,7 @@ const mapDispatchToProps = (dispatch, props) => {
     ...props,
     onClose: () => {
       props.onClose()
-      dispatch(setEvaluationsResponse([], { id: 0 }))
+      dispatch(setEvaluationsResponse([], { id: null, rating: 0 }))
     },
   }
 }

--- a/src/containers/SearchLecture.js
+++ b/src/containers/SearchLecture.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 import SearchLecture from '../components/molecules/SearchLecture'
-import { addToNotRecommendsRequest, clearSearchLecture, searchLectureRequest } from '../store/ttrs/actions'
+import { clearSearchLecture, searchLectureRequest } from '../store/ttrs/actions'
 
 const mapStateToProps = (state) => {
   return {

--- a/src/containers/SettingsTab.js
+++ b/src/containers/SettingsTab.js
@@ -37,8 +37,8 @@ const mapDispatchToProps = (dispatch) => {
     onDeleteFromNotRecommends: (notRecommends, courseId) => {
       dispatch(deleteFromNotRecommendsRequest(notRecommends, courseId))
     },
-    onClearError: () => {
-      dispatch(setErrors('settingsTab', {}))
+    onSetError: (errors) => {
+      dispatch(setErrors('settingsTab', errors))
     },
     onExit: () => {
       dispatch(clearState())

--- a/src/containers/SettingsTab.js
+++ b/src/containers/SettingsTab.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 import SettingsTab from '../components/organisms/SettingsTab'
-import { clearState, deleteFromNotRecommendsRequest, getNotRecommendCoursesRequest, setErrors,
+import { deleteFromNotRecommendsRequest, getNotRecommendCoursesRequest, setErrors,
   updateStudentInfoRequest, withdraw } from '../store/ttrs/actions'
 
 const mapStateToProps = (state) => {

--- a/src/containers/SettingsTab.js
+++ b/src/containers/SettingsTab.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import SettingsTab from '../components/organisms/SettingsTab'
-import { clearState, deleteFromNotRecommendsRequest, getNotRecommendCoursesRequest, setErrors, updateStudentInfoRequest, withdraw } from '../store/ttrs/actions'
+import { clearState, deleteFromNotRecommendsRequest, getNotRecommendCoursesRequest, setErrors,
+  updateStudentInfoRequest, withdraw } from '../store/ttrs/actions'
 
 const mapStateToProps = (state) => {
   return {
@@ -33,9 +34,6 @@ const mapDispatchToProps = (dispatch) => {
     },
     onSetError: (errors) => {
       dispatch(setErrors('settingsTab', errors))
-    },
-    onExit: () => {
-      dispatch(clearState())
     },
   }
 }

--- a/src/containers/SettingsTab.js
+++ b/src/containers/SettingsTab.js
@@ -1,16 +1,10 @@
 import { connect } from 'react-redux'
 import SettingsTab from '../components/organisms/SettingsTab'
-import {
-  clearState, deleteFromNotRecommendsRequest, getNotRecommendCoursesRequest, setErrors, setSuccess,
-  updateStudentInfoRequest,
-  withdraw
-} from '../store/ttrs/actions'
+import { clearState, deleteFromNotRecommendsRequest, getNotRecommendCoursesRequest, setErrors, updateStudentInfoRequest, withdraw } from '../store/ttrs/actions'
 
 const mapStateToProps = (state) => {
   return {
-    username: state.ttrs.studentInfo.username,
     password: state.ttrs.studentInfo.password,
-    email: state.ttrs.studentInfo.email,
     grade: state.ttrs.studentInfo.grade,
     college: state.ttrs.studentInfo.college,
     department: state.ttrs.studentInfo.department,

--- a/src/containers/SignIn.js
+++ b/src/containers/SignIn.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import SignIn from '../components/pages/SignIn'
 import { signInRequest, setErrors } from '../store/ttrs/actions'
+import { initialErrorUnit } from '../store/ttrs/selectors'
 
 const mapStateToProps = (state) => {
   return {
@@ -15,7 +16,7 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(signInRequest(username, password))
     },
     onClearError: () => {
-      dispatch(setErrors('signIn', {}))
+      dispatch(setErrors('signIn', initialErrorUnit))
     },
   }
 }

--- a/src/containers/SignUp.js
+++ b/src/containers/SignUp.js
@@ -19,9 +19,6 @@ const mapDispatchToProps = (dispatch) => {
     onSetError: (errors) => {
       dispatch(setErrors('signUp', errors))
     },
-    onExit: () => {
-      dispatch(clearState())
-    },
   }
 }
 

--- a/src/containers/SignUp.js
+++ b/src/containers/SignUp.js
@@ -7,6 +7,7 @@ const mapStateToProps = (state) => {
     toSignIn: state.ttrs.toSignIn,
     colleges: state.ttrs.belongInfo.colleges,
     errors: state.ttrs.error.signUp,
+    response: state.ttrs.response.signUp,
   }
 }
 
@@ -15,8 +16,8 @@ const mapDispatchToProps = (dispatch) => {
     onSignUp: (username, password, email, grade, college, department, major) => {
       dispatch(signUpRequest({ username, password, email, grade, college, department, major }))
     },
-    onClearError: () => {
-      dispatch(setErrors('signUp', {}))
+    onSetError: (errors) => {
+      dispatch(setErrors('signUp', errors))
     },
     onExit: () => {
       dispatch(clearState())

--- a/src/services/error_utility.js
+++ b/src/services/error_utility.js
@@ -14,17 +14,7 @@
  * texts has key-value pairs where key is field name of the error and value is the error message
  */
 
-import { convertToReadable } from './parser'
-
-/**
- * get initial error structure
- */
-export const initErrors = () => {
-  return {
-    bools: {},
-    texts: {},
-  }
-}
+import { convertToReadable, isInstanceOf } from './parser'
 
 /**
  * get semantic error structure from raw errors
@@ -49,41 +39,20 @@ export const initErrors = () => {
  *   },
  * }
  */
-export const getErrors = (rawErrors) => {
+export const processErrors = (rawErrors) => {
   const bools = {}
   const texts = {}
   Object.keys(rawErrors).forEach(field => {
     bools[field] = true
-    texts[field] = `${convertToReadable(field)}: ${rawErrors[field].join('\n')}`
+    if (isInstanceOf(rawErrors, 'Array')) {
+      texts[field] = `${convertToReadable(field)}: ${rawErrors[field].join('\n')}`
+    } else {
+      texts[field] = `${convertToReadable(field)}: ${rawErrors[field]}`
+    }
   })
   return {
     bools,
     texts,
-  }
-}
-
-/**
- * update semantic-UI-style error structure based on original error structure
- * @param original: original error structure
- * @param rawErrors: raw errors from backend
- * @returns updated semantic-UI-style error structure
- */
-export const updateErrors = (original, rawErrors) => {
-  const bools = {}
-  const texts = {}
-  Object.keys(rawErrors).forEach(field => {
-    bools[field] = true
-    texts[field] = `${convertToReadable(field)}: ${rawErrors[field].join('\n')}`
-  })
-  return {
-    bools: {
-      ...original.bools,
-      ...bools,
-    },
-    texts: {
-      ...original.texts,
-      ...texts,
-    },
   }
 }
 

--- a/src/services/parser.js
+++ b/src/services/parser.js
@@ -1,4 +1,4 @@
-const isInstanceOf = (obj, typeString) => Object.prototype.toString.call(obj).slice(8, -1) === typeString
+export const isInstanceOf = (obj, typeString) => Object.prototype.toString.call(obj).slice(8, -1) === typeString
 const isUpperCase = (char) => char.toLowerCase() !== char
 // const isLowerCase = (char) => char.toUpperCase() !== char
 

--- a/src/store/ttrs/reducer.js
+++ b/src/store/ttrs/reducer.js
@@ -244,21 +244,6 @@ const error = (state = initialError, action) => {
   switch (action.type) {
     case actions.CLEAR_STATE:
       return initialError
-    case actions.SIGN_UP_REQUEST:
-      return {
-        ...state,
-        signUp: {},
-      }
-    case actions.SIGN_IN_REQUEST:
-      return {
-        ...state,
-        signIn: {},
-      }
-    case actions.UPDATE_STUDENT_INFO_REQUEST:
-      return {
-        ...state,
-        settingsTab: {},
-      }
     case actions.SET_ERRORS:
       return {
         ...state,
@@ -277,16 +262,23 @@ const response = (state = initialResponse, action) => {
   switch (action.type) {
     case actions.CLEAR_STATE:
       return initialResponse
+    case actions.SIGN_UP_RESPONSE:
+      return {
+        ...state,
+        signUp: newResponse(state.signUp, true),
+      }
     case actions.UPDATE_STUDENT_INFO_RESPONSE:
       return {
         ...state,
         settingsTab: newResponse(state.settingsTab, true),
       }
     case actions.SET_ERRORS:
-      return {
-        ...state,
-        [action.identifier]: newResponse(state[action.identifier], false),
-      }
+      return (Object.keys(action.errors.bools).length > 0 || Object.keys(action.errors.texts).length > 0)
+        ? {
+          ...state,
+          [action.identifier]: newResponse(state[action.identifier], false),
+        }
+        : state
     default:
       return state
   }
@@ -309,6 +301,7 @@ const ttrsReducer = (state = initialState, action) => {
       return {
         ...state,
         toSignIn: true,
+        response: response(state.response, action),
       }
     case actions.CLEAR_STATE:
       return {

--- a/src/store/ttrs/sagas.js
+++ b/src/store/ttrs/sagas.js
@@ -293,6 +293,9 @@ function* selectBookmarkedTimeTable(bookmarkedTimeTable) {
  *   Delete Lecture from Bookmarked TimeTable
  */
 function* updateBookmarkedTimeTable(index, timeTableId, updatedInfo, newLectureId) {
+  if (newLectureId !== null && newLectureId > 0) {
+    updatedInfo.lectures.push(newLectureId)
+  }
   try {
     const response = yield call(axios.patch, `ttrs/bookmarked-time-tables/${timeTableId}/`, updatedInfo, config)
     console.log('update BookmarkedTimeTable response', response)

--- a/src/store/ttrs/sagas.js
+++ b/src/store/ttrs/sagas.js
@@ -3,6 +3,7 @@ import { take, put, call, fork } from 'redux-saga/effects'
 import * as actions from './actions'
 import { convertToCStyle, convertToJavaStyle, updateURLParams } from '../../services/parser'
 import { initialTimeTable, initialState } from './selectors'
+import { processErrors } from '../../services/error_utility'
 
 axios.defaults.baseURL = 'http://127.0.0.1:8000/'
 axios.interceptors.request.use((config) => {
@@ -125,7 +126,7 @@ function* signIn(username, password) {
     yield put(actions.signInResponse(response.data))
   } catch (error) {
     console.log('signIn error', error.response)
-    yield put(actions.setErrors('signIn', error.response.data))
+    yield put(actions.setErrors('signIn', processErrors(error.response.data)))
     return undefined
   }
   year = initialState.year
@@ -172,7 +173,7 @@ function* signUp(studentInfo) {
     yield put(actions.signUpResponse())
   } catch (error) {
     console.log('signUp error', error.response)
-    yield put(actions.setErrors('signUp', error.response.data))
+    yield put(actions.setErrors('signUp', processErrors(error.response.data)))
   }
 }
 
@@ -380,7 +381,7 @@ function* updateStudentInfo(info) {
     }
   } catch (error) {
     console.log('update student info error', error.response)
-    yield put(actions.setErrors('settingsTab', error.response.data))
+    yield put(actions.setErrors('settingsTab', processErrors(error.response.data)))
   }
 }
 

--- a/src/store/ttrs/sagas.js
+++ b/src/store/ttrs/sagas.js
@@ -376,8 +376,8 @@ function* updateStudentInfo(info) {
     if (info.password) {
       yield put(actions.clearState())
     } else {
-      delete response.password
-      yield put(actions.updateStudentInfoResponse(info))
+      delete response.data.password
+      yield put(actions.updateStudentInfoResponse(response.data))
     }
   } catch (error) {
     console.log('update student info error', error.response)

--- a/src/store/ttrs/selectors.js
+++ b/src/store/ttrs/selectors.js
@@ -85,6 +85,6 @@ export const initialState = {
   evaluations: [],
   lectureDetail: {
     id: null,
-    rate: null,
+    rating: 0,
   },
 }

--- a/src/store/ttrs/selectors.js
+++ b/src/store/ttrs/selectors.js
@@ -53,13 +53,19 @@ export const initialSearch = {
   lectures: [],
 }
 
+export const initialErrorUnit = {
+  bools: {},
+  texts: {},
+}
+
 export const initialError = {
-  signIn: {},
-  signUp: {},
-  settingsTab: {},
+  signIn: initialErrorUnit,
+  signUp: initialErrorUnit,
+  settingsTab: initialErrorUnit,
 }
 
 export const initialResponse = {
+  signUp: 0,
   settingsTab: 0,
 }
 


### PR DESCRIPTION
# Error Handling Simplification
- Error handling at `SignUp`, `SettingsTab` and `SignIn` becomes simpler than before.
- Both custom errors and backend errors are treated as the props of the component and modified by redux action and reducer.
- By Introducing `Notice` Component, the modularity has increased.

# Several Bug Fixes
**Resolved Bug List**
- Cannot create my timetable by `AddLecture`.
- Added a lecture to a `BookmarkedTimetable`, but actually did not.
- Cannot Add lecture on `ReceiveTab`.
- `Department` List and `Major` List does not changed when College index was changed in the `SignUp` and `SettingsTab`.
- Updated profile with `department` or `major` null, but it ignored.
- Previous error state is not reset even if the related component is unmounted before.
- When a `LecturePopup` component just has opened up, the rating is shown as `Nan` until the right data is received by saga.
- The page of the `SearchLecture` is not reset even when searching with different query.

# Enhancement
When a user signed up just before, the success `Notice` is shown for several seconds with a message;

> You have successfully joined the membership.
Return to sign in page...

After that, the page would be redirected to `SignIn` page automatically.