### PR TITLE
Send options on recommend request

### DIFF
--- a/src/components/molecules/TimeTable/index.js
+++ b/src/components/molecules/TimeTable/index.js
@@ -67,11 +67,6 @@ class TimeTable extends React.Component {
     this.props.onSend(sendInfo)
   }
 
-  getBlocks = (blocks) => {
-    console.log('Change in selected blocks')
-    console.log(blocks)
-  }
-
   handleChange = (e, { name, value }) => {
     this.setState({ [name]: value })
   }
@@ -84,7 +79,7 @@ class TimeTable extends React.Component {
           lectures={this.props.lectures}
           canDeleteLecture={this.props.canModify}
           onDeleteLecture={this.props.onDeleteLecture}
-          onChange={this.getBlocks}
+          onChange={this.props.onSelectBlocks ? this.props.onSelectBlocks : () => {}}
         />
       </div>
     )
@@ -344,6 +339,7 @@ TimeTable.propTypes = {
   onOpenSidebar: PropTypes.func,
   onShowPrevRecommend: PropTypes.func,
   onShowNextRecommend: PropTypes.func,
+  onSelectBlocks: PropTypes.func,
 }
 
 export default TimeTable

--- a/src/components/organisms/RecommendTab/index.js
+++ b/src/components/organisms/RecommendTab/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Divider, Form, Grid, Progress, Segment, Sidebar } from 'semantic-ui-react'
 import TimeTable from '../../../containers/TimeTable'
+import { compressBlocks } from '../../../services/parser'
 
 export const getLectureIds = (timeTable) => {
   const lectureIds = []
@@ -42,9 +43,23 @@ class RecommendTab extends React.Component {
     this.setState({ [name]: checked })
   }
 
+  handleRecommend = () => {
+    const options = {
+      avoidSuccessive: this.state.avoidSuccessiveLecture,
+      avoidVoid: this.state.avoidVoidLecture,
+      avoidFirst: this.state.avoidFirstLecture,
+      jeonpil: this.state.jeonpilWeight,
+      jeonseon: this.state.jeonseonWeight,
+      gyoyang: this.state.gyoyangWeight,
+      credit: this.state.creditUserWant,
+      blocks: compressBlocks(this.state.blocks),
+    }
+    this.props.onGetRecommendation(options)
+  }
+
   render() {
-    const weightSum = parseInt(this.state.jeonpilWeight) + parseInt(this.state.jeonseonWeight) + parseInt(this.state.gyoyangWeight)
-    const prevIndex = (this.props.recommendedTimeTables.length + this.state.recommendedTimeTableIndex - 1) % this.props.recommendedTimeTables.length
+    const weightSum = Number(this.state.jeonpilWeight) + Number(this.state.jeonseonWeight) + Number(this.state.gyoyangWeight)
+    const prevIndex = ((this.props.recommendedTimeTables.length + this.state.recommendedTimeTableIndex) - 1) % this.props.recommendedTimeTables.length
     const nextIndex = (this.state.recommendedTimeTableIndex + 1) % this.props.recommendedTimeTables.length
 
     return (
@@ -62,6 +77,7 @@ class RecommendTab extends React.Component {
           onDeleteLecture={(lectureId) => this.props.onUpdateMyTimeTable(this.props.myTimeTable.id, { lectures: getLectureIdsWithout(lectureId, this.props.myTimeTable) }, -lectureId)}
           onModifyContent={(content) => this.props.onUpdateMyTimeTable(this.props.myTimeTable.id, content, null)}
           onDeleteTimeTable={(timeTableId) => timeTableId !== null ? this.props.onDeleteTimeTable(timeTableId, 'my', null) : console.log('There is no timetable')}
+          onSelectBlocks={(blocks) => this.setState({ blocks })}
         />
         <Divider />
         <h1>Recommended TimeTable</h1>
@@ -190,7 +206,7 @@ class RecommendTab extends React.Component {
                       color="teal"
                       content="Recommend"
                       onClick={() => {
-                        this.props.onGetRecommendation()
+                        this.handleRecommend()
                         this.setState({ sidebarVisible: false })
                       }}
                     />

--- a/src/containers/RecommendTab.js
+++ b/src/containers/RecommendTab.js
@@ -23,8 +23,8 @@ const mapDispatchToProps = (dispatch) => {
     onSelectRecommendedTimeTable: (recommendedTimeTable) => {
       dispatch(selectRecommendedTimeTableRequest(recommendedTimeTable))
     },
-    onGetRecommendation: () => {
-      dispatch(getRecommendationRequest())
+    onGetRecommendation: (options) => {
+      dispatch(getRecommendationRequest(options))
     },
   }
 }

--- a/src/containers/TimeTable.js
+++ b/src/containers/TimeTable.js
@@ -36,6 +36,7 @@ const mapDispatchToProps = (dispatch, props) => {
     onOpenSidebar: props.onOpenSidebar,
     onShowPrevRecommend: props.onShowPrevRecommend,
     onShowNextRecommend: props.onShowNextRecommend,
+    onSelectBlocks: props.onSelectBlocks,
   }
 }
 

--- a/src/services/parser.js
+++ b/src/services/parser.js
@@ -104,3 +104,52 @@ export const convertToReadable = (key) => {
   }
   return words.join(' ')
 }
+
+export const compressBlocks = (_blocks) => {
+  let blocks = _blocks
+  if (blocks === null || blocks === undefined) {
+    blocks = []
+    for (let i = 0; i < 24; i += 1) {
+      blocks.push([])
+      for (let j = 0; j < 6; j += 1) {
+        blocks[i].push(true)
+      }
+    }
+  }
+  let empty = true
+  for (let i = 0; i < 24; i += 1) {
+    for (let j = 0; j < 6; j += 1) {
+      if (blocks[i][j]) {
+        empty = false
+      }
+    }
+  }
+  if (empty) {
+    for (let i = 0; i < 24; i += 1) {
+      for (let j = 0; j < 6; j += 1) {
+        blocks[i][j] = true
+      }
+    }
+  }
+  blocks.push([])
+  for (let j = 0; j < 6; j += 1) {
+    blocks[24].push(false)
+  }
+  const days = []
+  for (let j = 0; j < 6; j += 1) {
+    const slots = []
+    let start = null
+    for (let i = 0; i < 25; i += 1) {
+      if (!blocks[i][j]) {
+        if (start !== null) {
+          slots.push(`${start + 18}:${i + 18}`)
+          start = null
+        }
+      } else if (start === null) {
+        start = i
+      }
+    }
+    days.push(slots.join(','))
+  }
+  return days.join('|')
+}

--- a/src/store/ttrs/actions.js
+++ b/src/store/ttrs/actions.js
@@ -499,8 +499,9 @@ export const setFieldsAndTypes = (fields, types) => {
   }
 }
 
-export const getRecommendationRequest = () => {
+export const getRecommendationRequest = (options) => {
   return {
     type: GET_RECOMMENDATION_REQUEST,
+    options,
   }
 }

--- a/src/store/ttrs/sagas.js
+++ b/src/store/ttrs/sagas.js
@@ -570,10 +570,11 @@ function* toggleLikeIt(lectureId, isAdd, evaluationId) {
   }
 }
 
-function* getRecommendation() {
+function* getRecommendation(options) {
   const params = {
     year,
     semester,
+    ...options,
   }
   try {
     const response = yield call(axios.get, updateURLParams('ttrs/recommends/', params), config)
@@ -747,8 +748,8 @@ function* watchToggleLikeIt() {
 
 function* watchGetRecommendation() {
   while (true) {
-    yield take(actions.GET_RECOMMENDATION_REQUEST)
-    yield call(getRecommendation)
+    const { options } = yield take(actions.GET_RECOMMENDATION_REQUEST)
+    yield call(getRecommendation, options)
   }
 }
 


### PR DESCRIPTION
Now the backend can receive recommend request with some options including block selection.

For example,
![image](https://user-images.githubusercontent.com/24453019/41497988-a1660c94-719c-11e8-86cd-9fb181f3ba11.png)
If the request is called with this state, the backend would get query params like this,
```python3
{'avoid_first': ['true'], 'semester': ['여름학기'], 'avoid_void': ['true'], 'jeonseon': ['464'], 'jeonpil': ['250'], 'gyoyang': ['250'], 'year': ['2018'], 'credit': ['9'], 'blocks': ['32:39|34:35,38:40|36:42|38:39||36:39'], 'avoid_successive': ['false']}
```