### PR TITLE
Prevent adding lecture to the incompatible time table & Enable to search on empty area of the time table

### DIFF
--- a/src/components/atoms/Lecture/index.js
+++ b/src/components/atoms/Lecture/index.js
@@ -85,7 +85,7 @@ class Lecture extends React.Component {
               content={<div>
                 Intersects with
                 {this.props.intersects.map((other) => (
-                  <div>{other.course.name}</div>
+                  <div key={other.id}>{other.course.name}</div>
                 ))}
               </div>}
               flowing

--- a/src/components/atoms/Lecture/index.js
+++ b/src/components/atoms/Lecture/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button, Card, List } from 'semantic-ui-react'
+import { Button, Card, List, Popup } from 'semantic-ui-react'
 import TimeSlot from '../TimeSlot'
 import LecturePopup from '../../../containers/LecturePopup'
 
@@ -74,7 +74,28 @@ class Lecture extends React.Component {
               content="Details"
               onClick={() => this.setState({ open: true })}
             />
-            <Button basic color="blue" content="Add" onClick={this.props.onAddLecture} />
+            {this.props.intersects.length > 0
+            ? <Popup
+              trigger={<Button
+                basic
+                color="red"
+                content="Add"
+              />}
+              header="Cannot add this lecture to the time table"
+              content={<div>
+                Intersects with
+                {this.props.intersects.map((other) => (
+                  <div>{other.course.name}</div>
+                ))}
+              </div>}
+              flowing
+            />
+            : <Button
+              basic
+              color="blue"
+              content="Add"
+              onClick={this.props.onAddLecture}
+            />}
           </div>
         </Card.Content>
         {this.state.open &&
@@ -91,6 +112,7 @@ class Lecture extends React.Component {
 
 Lecture.propTypes = {
   lecture: PropTypes.object,
+  intersects: PropTypes.array,
   onAddLecture: PropTypes.func,
 }
 

--- a/src/components/molecules/SearchLecture/index.js
+++ b/src/components/molecules/SearchLecture/index.js
@@ -354,6 +354,7 @@ class SearchLecture extends React.Component {
                 totalPages={Math.floor((this.props.count - 1) / limit) + 1}
                 activePage={this.state.page}
                 onPageChange={this.handlePageChange}
+                siblingRange={3}
               />
             </div>}
             <Button onClick={this.props.onClose} content="Close" />

--- a/src/components/molecules/SearchLecture/index.js
+++ b/src/components/molecules/SearchLecture/index.js
@@ -25,6 +25,26 @@ class SearchLecture extends React.Component {
     page: 1,
   }
 
+  getIntersects = (lectures, lecture) => {
+    const intersects = []
+    lectures.forEach((other) => {
+      let intersect = false
+      other.timeSlots.forEach((slot1) => {
+        lecture.timeSlots.forEach((slot2) => {
+          if (slot1.dayOfWeek === slot2.dayOfWeek) {
+            if (slot1.endTime > slot2.startTime && slot1.startTime < slot2.endTime) {
+              intersect = true
+            }
+          }
+        })
+      })
+      if (intersect) {
+        intersects.push(other)
+      }
+    })
+    return intersects
+  }
+
   handleChange = (e, { name, value }) => {
     this.setState({ [name]: value })
   }
@@ -338,6 +358,7 @@ class SearchLecture extends React.Component {
                   key={lecture.id}
                   lecture={lecture}
                   onAddLecture={() => this.props.onAddLecture(lecture.id)}
+                  intersects={this.getIntersects(this.props.lectures, lecture)}
                 />
               )}
             </Card.Group>
@@ -372,6 +393,7 @@ SearchLecture.propTypes = {
   fields: PropTypes.object,
   types: PropTypes.array,
   blocks: PropTypes.array,
+  lectures: PropTypes.array,
 
   onSearchLecture: PropTypes.func,
   onClose: PropTypes.func,

--- a/src/components/molecules/TimeTable/index.js
+++ b/src/components/molecules/TimeTable/index.js
@@ -192,11 +192,11 @@ class TimeTable extends React.Component {
               position="bottom left"
               flowing
               trigger={<div><Icon name="lightbulb" />Selection</div>}
-              content={<div><h5>
-                {'You can select blocks by mouse dragging!'}<br />
+              header="You can select blocks by mouse dragging!"
+              content={<div>
                 {'Hold \'ctrl\' to unselect, \'shift\' to toggle blocks.'}<br />
                 {'Select columns/rows or whole table by dragging table headers.'}
-              </h5></div>}
+              </div>}
             />}
           </Menu.Item>}
           <Menu.Menu position="right">

--- a/src/components/molecules/TimeTable/index.js
+++ b/src/components/molecules/TimeTable/index.js
@@ -215,6 +215,7 @@ class TimeTable extends React.Component {
                     onAddLecture={this.props.onAddLecture}
                     onClose={() => this.setState({ searchOpen: false })}
                     blocks={this.state.blocks}
+                    lectures={this.props.lectures}
                   />}
                 </div>}
                 content="Add a lecture to this timetable"

--- a/src/components/organisms/RecommendTab/index.js
+++ b/src/components/organisms/RecommendTab/index.js
@@ -101,8 +101,7 @@ class RecommendTab extends React.Component {
                 <Form style={{ float: 'right', marginRight: -14 }}>
                   <Form.Group inline>
                     <Form.Dropdown
-                      simple item
-                      fluid
+                      simple
                       placeholder="TimeTable"
                       options={timeTableOptions}
                       name="timeTable"

--- a/src/components/organisms/SettingsTab/index.js
+++ b/src/components/organisms/SettingsTab/index.js
@@ -1,9 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {
-  Form, Message, Button, Header, Divider, Popup, List, Grid, Dimmer, Loader,
-  Transition
-} from 'semantic-ui-react'
+import { Form, Message, Button, Header, Divider, Popup, List, Grid, Dimmer, Loader } from 'semantic-ui-react'
 import { customErrors } from '../../../services/error_utility'
 import { initialErrorUnit } from '../../../store/ttrs/selectors'
 

--- a/src/components/organisms/SettingsTab/index.js
+++ b/src/components/organisms/SettingsTab/index.js
@@ -1,6 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Form, Message, Button, Header, Divider, Popup, List, Grid, Dimmer, Loader } from 'semantic-ui-react'
+import {
+  Form, Message, Button, Header, Divider, Popup, List, Grid, Dimmer, Loader,
+  Transition
+} from 'semantic-ui-react'
 import { customErrors } from '../../../services/error_utility'
 import { initialErrorUnit } from '../../../store/ttrs/selectors'
 
@@ -231,23 +234,25 @@ class SettingsTab extends React.Component {
                 <Header as="h2" content="Not Recommends" />
                 <List verticalAlign="middle" ordered>
                   {this.props.notRecommendCourses.map((course) => (
-                    <List.Item key={course.id}>
-                      <List.Content floated="right">
-                        <Popup
-                          trigger={<Button
-                            icon="delete"
-                            color="red"
+                    <Transition transitionOnMount>
+                      <List.Item key={course.id}>
+                        <List.Content floated="right">
+                          <Popup
+                            trigger={<Button
+                              icon="delete"
+                              color="red"
+                              inverted
+                              onClick={() => this.props.onDeleteFromNotRecommends(this.props.notRecommends, course.id)}
+                            />}
+                            content="Allow to recommend this course from now."
                             inverted
-                            onClick={() => this.props.onDeleteFromNotRecommends(this.props.notRecommends, course.id)}
-                          />}
-                          content="Allow to recommend this course from now."
-                          inverted
-                        />
-                      </List.Content>
-                      <List.Header as="h3">
-                        {course.name}
-                      </List.Header>
-                    </List.Item>
+                          />
+                        </List.Content>
+                        <List.Header as="h3">
+                          {course.name}
+                        </List.Header>
+                      </List.Item>
+                    </Transition>
                   ))}
                 </List>
               </div>

--- a/src/components/organisms/SettingsTab/index.js
+++ b/src/components/organisms/SettingsTab/index.js
@@ -234,25 +234,23 @@ class SettingsTab extends React.Component {
                 <Header as="h2" content="Not Recommends" />
                 <List verticalAlign="middle" ordered>
                   {this.props.notRecommendCourses.map((course) => (
-                    <Transition transitionOnMount>
-                      <List.Item key={course.id}>
-                        <List.Content floated="right">
-                          <Popup
-                            trigger={<Button
-                              icon="delete"
-                              color="red"
-                              inverted
-                              onClick={() => this.props.onDeleteFromNotRecommends(this.props.notRecommends, course.id)}
-                            />}
-                            content="Allow to recommend this course from now."
+                    <List.Item key={course.id}>
+                      <List.Content floated="right">
+                        <Popup
+                          trigger={<Button
+                            icon="delete"
+                            color="red"
                             inverted
-                          />
-                        </List.Content>
-                        <List.Header as="h3">
-                          {course.name}
-                        </List.Header>
-                      </List.Item>
-                    </Transition>
+                            onClick={() => this.props.onDeleteFromNotRecommends(this.props.notRecommends, course.id)}
+                          />}
+                          content="Allow to recommend this course from now."
+                          inverted
+                        />
+                      </List.Content>
+                      <List.Header as="h3">
+                        {course.name}
+                      </List.Header>
+                    </List.Item>
                   ))}
                 </List>
               </div>

--- a/src/containers/Lecture.js
+++ b/src/containers/Lecture.js
@@ -4,6 +4,7 @@ import Lecture from '../components/atoms/Lecture'
 const mapStateToProps = (state, props) => {
   return {
     lecture: props.lecture,
+    intersects: props.intersects,
   }
 }
 

--- a/src/containers/SearchLecture.js
+++ b/src/containers/SearchLecture.js
@@ -10,6 +10,7 @@ const mapStateToProps = (state, props) => {
     fields: state.ttrs.fields,
     types: state.ttrs.types,
     blocks: props.blocks,
+    lectures: props.lectures,
   }
 }
 


### PR DESCRIPTION
# Prevent adding lecture to the incompatible time table
![image](https://user-images.githubusercontent.com/24453019/41549198-061b3fdc-7360-11e8-8cf0-646bb8f73f92.png)
Red `Add` Button click does not invoke adding lecture request.
Intersected lectures are shown in popup.

# Enable to search on empty area of the time table
![image](https://user-images.githubusercontent.com/24453019/41552636-44fd19d2-736a-11e8-856d-02d7e9fb92f6.png)
The searched lectures are always compatible to the time table if the switch is on.

###  **Additional**
- increase sibling range of the pagination of the SearchLecture.
- modify selection tip popup message.
![image](https://user-images.githubusercontent.com/24453019/41552614-3ac4205a-736a-11e8-8ecb-f35385f925c3.png)

